### PR TITLE
Make example conf valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add `jsdoc-strip-async-await` to your jsdoc config file.
 [Configuring JSDoc with conf.json](http://usejsdoc.org/about-configuring-jsdoc.html)
 ```json
 {
-  "plugins": ["node_modules/jsdoc-strip-async-await"],
+  "plugins": ["node_modules/jsdoc-strip-async-await"]
 }
 ```
 


### PR DESCRIPTION
Also in my case I had to use "node_modules/jsdoc-strip-async-await/index" (with index) but I didn't include that here, maybe I'm missing something..
