### PR TITLE
Use whitespace instead of word boundary and ignore import

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,23 +8,23 @@
 /* eslint spaced-comment: 0 */
 
 // Regex that matches await and async, but ignoring matches in comments or strings.
-var re = /\/\/[^\r\n]*[\r\n]+|\/\*[\s\S]*?\*\/|(["'`])(?:\\\1|(?!\1).)*\1|\b(await\b\s*|async\b\s*)/g;
+var re = /\/\/[^\r\n]*[\r\n]+|\/\*[\s\S]*?\*\/|import\s+.*|(["'`])(?:\\\1|(?!\1).)*\1|\b(await\s+|async\s+)/g;
 
 exports.handlers = {
-	///
-	/// Remove async and await keywords
-	///
-	/// @param e
-	/// @param e.filename
-	/// @param e.source
-	///
-	beforeParse: function (e) {
-		e.source = e.source.replace(re, function () {
-			if (arguments[0] === arguments[2]) {
-				return '';
-			}
+  ///
+  /// Remove async and await keywords
+  ///
+  /// @param e
+  /// @param e.filename
+  /// @param e.source
+  ///
+  beforeParse: function(e) {
+    e.source = e.source.replace(re, function() {
+      if (arguments[0] === arguments[2]) {
+        return '';
+      }
 
-			return arguments[0];
-		});
-	}
+      return arguments[0];
+    });
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "jsdoc-strip-async-await",
+  "version": "0.1.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Hi there,

Thanks for the plugin!

My problem was that both this pattern
```
import async from 'async'
```

And this pattern

```
async.someFunction()
```

Where being captured leading to some errors.

I've replaced he word boundary matching after async and await to one space or more, and ignore lines with `import` in them.

I've did some very basic tests here:
https://regex101.com/r/bNkTut/1

Cheers!

Jun