### PR TITLE
Fixed so that it does not act on functions called async/await

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 /* eslint spaced-comment: 0 */
 
 // Regex that matches await and async, but ignoring matches in comments or strings.
-var re = /\/\/[^\r\n]*[\r\n]+|\/\*[\s\S]*?\*\/|(["'`])(?:\\\1|(?!\1).)*\1|\b(await\b\s*|async\b\s*)/g;
+var re = /\/\/[^\r\n]*[\r\n]+|\/\*[\s\S]*?\*\/|(["'`])(?:\\\1|(?!\1).)*\1|[^.]\b(await\b\s*|async\b\s*)/g;
 
 exports.handlers = {
 	///


### PR DESCRIPTION
I've modified the regex to ignore instances of **async/await** that start with a dot so as to ignore the scenario described in #4.